### PR TITLE
Tweak readme and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ type Commands = {
 ### 3. Add types to `ipcMain` and `ipcRenderer`
 
 ```ts
+import { TypedIpcMain, TypedIpcRenderer } from "electron-typed-ipc";
+
 const typedIpcMain = ipcMain as TypedIpcMain<Events, Commands>;
 const typesIpcRenderer = ipcRenderer as TypedIpcRenderer<Events, Commands>;
 ```

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "name": "electron-typed-ipc",
   "author": "Andrei Canta",
+  "homepage": "https://github.com/deiucanta/electron-typed-ipc",
   "module": "dist/electron-typed-ipc.esm.js",
   "devDependencies": {
     "husky": "^4.2.5",


### PR DESCRIPTION
Thank you for releasing electron-typed-ipc! The API is straightforward and nicer than other similar libaries I think.

Here are some tweaks I made to the readme to package.json:

* Added an import line to example code in the readme
* Added the homepage URL to package.json, as currently it's hard to find the GitHub repository from Google