### PR TITLE
feat: Add support for webContents.ipc

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ type Commands = {
 ### 3. Add types to `ipcMain` and `ipcRenderer`
 
 ```ts
-import { TypedIpcMain, TypedIpcRenderer } from "electron-typed-ipc";
+import { TypedIpcMain, TypedIpcRenderer } from 'electron-typed-ipc';
 
 const typedIpcMain = ipcMain as TypedIpcMain<Events, Commands>;
 const typesIpcRenderer = ipcRenderer as TypedIpcRenderer<Events, Commands>;
@@ -57,7 +57,10 @@ typedIpcRenderer.on('configUpdated', (_, newConfig, oldConfig) => {
 // main.ts
 webContents
   .getAllWebContents()
-  .forEach((renderer: TypedWebContents<Events>) => {
-    renderer.send('configUpdated', newConfig, oldConfig);
+  .forEach((typedWebContents: TypedWebContents<Events, Commands>) => {
+    typedWebContents.send('configUpdated', newConfig, oldConfig);
+    typedWebContents.ipc.handle('fetchConfig', () => {
+      return { a: 1, b: 'text' };
+    });
   });
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,10 +95,13 @@ export interface TypedIpcRenderer<
   ): Promise<ReturnType<IpcCommands[K]>>;
 }
 
-export interface TypedWebContents<IpcEvents extends InputMap>
-  extends WebContents {
+export interface TypedWebContents<
+  IpcEvents extends InputMap,
+  IpcCommands extends InputMap
+> extends WebContents {
   send<K extends keyof IpcEvents>(
     channel: K,
     ...args: Parameters<IpcEvents[K]>
   ): void;
+  ipc: TypedIpcMain<IpcEvents, IpcCommands>;
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -36,7 +36,7 @@ typedIpcRenderer.on('configUpdated', (_, newConfig, oldConfig) => {
 
 webContents
   .getAllWebContents()
-  .forEach((renderer: TypedWebContents<Events>) => {
+  .forEach((typedWebContents: TypedWebContents<Events, Commands>) => {
     const newConfig = {
       a: 2,
       b: 'text2',
@@ -45,5 +45,17 @@ webContents
       a: 1,
       b: 'text1',
     };
-    renderer.send('configUpdated', newConfig, oldConfig);
+    typedWebContents.send('configUpdated', newConfig, oldConfig);
+
+    typedWebContents.ipc.on('configUpdated', (_, newConfig, oldConfig) => {
+      console.log(newConfig, oldConfig);
+    });
+
+    typedWebContents.ipc.handle('fetchConfig', () => {
+      return { a: 2, b: 'text2' };
+    });
+
+    typedWebContents.ipc.handle('updateConfig', (_, newConfig) => {
+      console.log(newConfig);
+    });
   });


### PR DESCRIPTION
Adds support for [webContents.ipc](https://www.electronjs.org/docs/latest/api/web-contents#contentsipc-readonly).

This may cause Typescript syntax errors in some existing code though because the new TypedWebContents will require a `Commands` argument in addition to `Events`. Might be a nice opportunity to 

This pull request includes multiple changes to improve type safety and functionality for `TypedWebContents` and `TypedIpcRenderer` in the `electron-typed-ipc` package. The most important changes include adding new handlers and updating type definitions to ensure better type coverage and functionality.

Also updated README.md and test.ts to reflect this change.